### PR TITLE
Add prop to allow specifying className for the paginator

### DIFF
--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -13,10 +13,12 @@ var Paginator = React.createClass({
         page: React.PropTypes.number,
         beginPages: React.PropTypes.number,
         endPages: React.PropTypes.number,
+        paginatorClass: React.PropTypes.string,
     },
     getDefaultProps() {
         return {
-            onSelect: noop
+            onSelect: noop,
+            paginatorClass: 'paginator'
         };
     },
     render() {
@@ -29,7 +31,7 @@ var Paginator = React.createClass({
         });
 
         return (
-            <ul className='pagination'>{
+            <ul className={this.props.paginatorClass}>{
                 segments.map((num, i) =>
                     num >= 0? <li
                         key={'pagination-' + i}

--- a/style2.css
+++ b/style2.css
@@ -1,0 +1,24 @@
+.pagify-pagination {
+    margin: 1em;
+    padding: 0;
+
+    list-style: none;
+}
+.pagify-pagination li {
+    margin: 0;
+    margin-right: 1em;
+    padding: 0.5em;
+
+    display: inline-block;
+
+    background: #ddd;
+}
+.pagify-pagination a {
+    text-decoration: none;
+}
+.pagify-pagination .selected {
+    background: #222;
+}
+.pagify-pagination .selected a {
+    color: #eee;
+}


### PR DESCRIPTION
This is to allow working around conflicts with the Bootstrap paginator
css class. The page number displays get messed up by the Bootstrap css.
The style2.css files provides an alternate version of style that works
in a bootstrap environment.