### PR TITLE
Add optional ellipsesClassName prop

### DIFF
--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -30,19 +30,32 @@ var Paginator = React.createClass({
             return a.concat(-1).concat(b);
         });
 
-        return (
-            <ul className={this.props.className}>{
-                segments.map((num, i) =>
-                    num >= 0? <li
+        var items = segments.map((num, i) => {
+            if (num >= 0) {
+                return (
+                    <li
                         key={'pagination-' + i}
                         onClick={onSelect.bind(null, num)}
-                        className={num === page && 'selected'}>
+                        className={num === page && 'selected'}
+                    >
                         <a href='#' onClick={this.preventDefault}>
                             {num + 1}
                         </a>
-                    </li>: <li key={'pagination-' + i}>&hellip;</li>
-                )
-            }</ul>
+                    </li>
+                );
+            }
+
+            return (
+                <li key={'pagination-' + i}>
+                    &hellip;
+                </li>
+            );
+        });
+
+        return (
+            <ul className={this.props.className}>
+                {items}
+            </ul>
         );
     },
 

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -14,11 +14,13 @@ var Paginator = React.createClass({
         beginPages: React.PropTypes.number,
         endPages: React.PropTypes.number,
         className: React.PropTypes.string,
+        ellipsesClassName: React.PropTypes.string,
     },
     getDefaultProps() {
         return {
             onSelect: noop,
-            className: 'pagify-pagination'
+            className: 'pagify-pagination',
+            ellipsesClassName: ''
         };
     },
     render() {
@@ -46,7 +48,10 @@ var Paginator = React.createClass({
             }
 
             return (
-                <li key={'pagination-' + i}>
+                <li
+                    key={'pagination-' + i}
+                    className={this.props.ellipsesClassName}
+                >
                     &hellip;
                 </li>
             );


### PR DESCRIPTION
Adds a prop to apply a class name to the ellipses, which can be useful for styling them differently than the page links. 

I also moved the segments.map() from the render function's return statement to a variable because it was getting unwieldy. Let me know if you'd prefer to keep it the way it was; I could submit another PR. 