### PR TITLE
Allow the active class name to be set through the props.

### DIFF
--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -20,6 +20,7 @@ var Paginator = React.createClass({
         ellipsesClassName: React.PropTypes.string,
         prevClassName: React.PropTypes.string,
         nextClassName: React.PropTypes.string,
+        activeClassName: React.PropTypes.string,
         inactiveClassName: React.PropTypes.string,
         prevButton: React.PropTypes.node,
         nextButton: React.PropTypes.node
@@ -32,7 +33,8 @@ var Paginator = React.createClass({
             ellipsesClassName: '',
             prevClassName: 'pagify-prev',
             nextClassName: 'pagify-next',
-            inactiveClassName: 'pagify-disabled',
+            activeClassName: 'selected',
+            inactiveClassName: 'pagify-disabled'
         };
     },
     render() {
@@ -45,6 +47,7 @@ var Paginator = React.createClass({
             alwaysShowPrevNext,
             prevClassName,
             nextClassName,
+            activeClassName,
             inactiveClassName,
         } = this.props;
 
@@ -59,7 +62,7 @@ var Paginator = React.createClass({
                     <li
                         key={'pagination-' + i}
                         onClick={onSelect.bind(null, num)}
-                        className={num === page && 'selected'}
+                        className={num === page && activeClassName || ''}
                     >
                         <a href='#' onClick={this.preventDefault}>
                             {num + 1}


### PR DESCRIPTION
The [bootstrap pagination](http://getbootstrap.com/components/#pagination) class uses `active` to highlight the current page rather than `selected`. This PR allows the active class name to be set through the props using `activeClassName`, like `inactiveClassName`.

Another change that was made is the class name each `li` was set using `num === page && 'selected'`. This had the side effect of setting the class name to `'false'` on every element that wasn't the current page. This change also makes the class name an empty string rather than `'false'`.