### PR TITLE
move lodash to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "html-webpack-plugin": "^2.7.2",
     "jest-cli": "^0.8.2",
     "json-loader": "^0.5.4",
-    "lodash": "^4.0.1",
     "purecss": "^0.6.0",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
@@ -63,7 +62,8 @@
     "webpack-merge": "^0.7.3"
   },
   "peerDependencies": {
-    "react": ">=0.13.* <1.0.0 || > 0.14.0-alpha"
+    "react": ">=0.13.* <1.0.0 || > 0.14.0-alpha",
+    "lodash": "^4.3.0"
   },
   "repository": {
     "type": "git",
@@ -93,6 +93,5 @@
     "test:lint"
   ],
   "dependencies": {
-    "lodash.merge": "^4.1.0"
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import merge from 'lodash.merge';
+import merge from 'lodash/merge';
 
 const defaultTags = {
   container: {


### PR DESCRIPTION
This PR avoids lodash.merge duplication and saves a few kB of code size.
In the current situationm, below is the webpack-bundle-size-analyzer report, notice that `lodash.merge` is responsible for  91.4% of the total size:
```
react-pagify: 96.12 KB (2.94%)
  lodash.merge: 87.88 KB (91.4%)
    lodash._stack: 18.16 KB (20.7%)
      lodash._mapcache: 12.38 KB (68.2%)
        <self>: 12.38 KB (100%)
      <self>: 5.77 KB (31.8%)
    lodash.keys: 11.26 KB (12.8%)
      <self>: 11.26 KB (100%)
    lodash.keysin: 11.17 KB (12.7%)
      <self>: 11.17 KB (100%)
    lodash.rest: 6.74 KB (7.67%)
      <self>: 6.74 KB (100%)
    lodash.isplainobject: 3.11 KB (3.54%)
      <self>: 3.11 KB (100%)
    lodash._root: 1.87 KB (2.13%)
      <self>: 1.87 KB (100%)
    lodash._basefor: 1.53 KB (1.74%)
      <self>: 1.53 KB (100%)
    lodash._arrayeach: 942 B (1.05%)
      <self>: 942 B (100%)
    <self>: 33.13 KB (37.7%)
  <self>: 8.24 KB (8.58%)
```