### PR TITLE
Migrate to React 15.5

### DIFF
--- a/__tests__/paginator-test.jsx
+++ b/__tests__/paginator-test.jsx
@@ -3,7 +3,7 @@
 jest.autoMockOff();
 
 const React = require('react');
-const TestUtils = require('react-addons-test-utils');
+const TestUtils = require('react-dom/test-utils');
 
 const Paginator = require('../src/index.jsx').default;
 

--- a/package.json
+++ b/package.json
@@ -49,9 +49,8 @@
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
     "purecss": "^0.6.0",
-    "react": "^15.2.0",
-    "react-addons-test-utils": "^15.2.0",
-    "react-dom": "^15.2.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "react-ghfork": "^0.3.5",
     "segmentize": "^0.4.1",
     "style-loader": "^0.13.1",
@@ -62,7 +61,7 @@
     "webpack-merge": "^0.14.0"
   },
   "peerDependencies": {
-    "react": ">= 0.13.* < 16.0.0",
+    "react": ">= 0.15.3 < 16.0.0",
     "lodash": ">= 4.3.0 < 5.0.0"
   },
   "repository": {
@@ -92,5 +91,7 @@
     "test",
     "test:lint"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "prop-types": "^15.5.8"
+  }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import merge from 'lodash/merge';
 
 const defaultTags = {
@@ -41,15 +42,15 @@ class Context extends React.Component {
   }
 }
 Context.propTypes = {
-  children: React.PropTypes.any,
-  onSelect: React.PropTypes.func,
-  segments: React.PropTypes.object,
-  tags: React.PropTypes.object
+  children: PropTypes.any,
+  onSelect: PropTypes.func,
+  segments: PropTypes.object,
+  tags: PropTypes.object
 };
 Context.childContextTypes = {
-  onSelect: React.PropTypes.func,
-  segments: React.PropTypes.object,
-  tags: React.PropTypes.object
+  onSelect: PropTypes.func,
+  segments: PropTypes.object,
+  tags: PropTypes.object
 };
 
 class Segment extends React.Component {
@@ -72,12 +73,12 @@ class Segment extends React.Component {
   }
 }
 Segment.propTypes = {
-  field: React.PropTypes.string.isRequired
+  field: PropTypes.string.isRequired
 };
 Segment.contextTypes = {
-  onSelect: React.PropTypes.func,
-  segments: React.PropTypes.object,
-  tags: React.PropTypes.object
+  onSelect: PropTypes.func,
+  segments: PropTypes.object,
+  tags: PropTypes.object
 };
 
 class Button extends React.Component {
@@ -97,12 +98,12 @@ class Button extends React.Component {
   }
 }
 Button.propTypes = {
-  children: React.PropTypes.any,
-  page: React.PropTypes.number.isRequired
+  children: PropTypes.any,
+  page: PropTypes.number.isRequired
 };
 Button.contextTypes = {
-  onSelect: React.PropTypes.func,
-  tags: React.PropTypes.object
+  onSelect: PropTypes.func,
+  tags: PropTypes.object
 };
 
 class Ellipsis extends React.Component {
@@ -124,13 +125,13 @@ class Ellipsis extends React.Component {
   }
 }
 Ellipsis.propTypes = {
-  children: React.PropTypes.any,
-  previousField: React.PropTypes.string.isRequired,
-  nextField: React.PropTypes.string.isRequired,
+  children: PropTypes.any,
+  previousField: PropTypes.string.isRequired,
+  nextField: PropTypes.string.isRequired,
 };
 Ellipsis.contextTypes = {
-  segments: React.PropTypes.object,
-  tags: React.PropTypes.object
+  segments: PropTypes.object,
+  tags: PropTypes.object
 };
 
 export default {


### PR DESCRIPTION
Fixes new [deprecation warnings](https://facebook.github.io/react/blog/#new-deprecation-warnings) introduced by React 15.5
- ```React.PropTypes``` migrated to use [prop-types](https://www.npmjs.com/package/prop-types) package
- Removes the [now deprecated](https://facebook.github.io/react/blog/#react-test-utils) ```react-addons-test-utils``` in favour of ```react-dom/test-utils```